### PR TITLE
Fix chapter 4 equipment menu

### DIFF
--- a/Final Fantasy XIII/Chapters/chapter4.tex
+++ b/Final Fantasy XIII/Chapters/chapter4.tex
@@ -424,7 +424,7 @@
 			\begin{itemize}
 				\item Sazh
 				      \begin{itemize}
-					      \item Optimize: Balanced (Vega 42s \& PW)
+					      \item Optimize: Offensive (Vega 42s \& PW)
 				      \end{itemize}
 			\end{itemize}
 		\end{itemize}


### PR DESCRIPTION
Would like a confirmation from a runner but it seems that `Offensive` is correct for menu before 4x Bomb + Pulsework Soldier fights.